### PR TITLE
feat: add custom canonical for derivtech

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -8,6 +8,14 @@
     <link rel="stylesheet" href="{{asset "built/screen.css"}}">
 
     {{ghost_head}}
+
+     {{#if custom_canonical_url}}
+        <!-- If custom canonical URL is specified -->
+        <link rel="canonical" href="{{custom_canonical_url}}">
+    {{else}}
+        <!-- Override default canonical URL with a new constant URL -->
+        <link rel="canonical" href="hthttps://deriv.com/derivtech">
+    {{/if}}
 </head>
 
 <body class="{{body_class}}{{block "body_class"}}  is-head-{{#match @custom.navigation_layout "Logo on the left"}}left-logo{{else match @custom.navigation_layout "Logo in the middle"}}middle-logo{{else}}stacked{{/match}}{{#match @custom.title_font "=" "Elegant serif"}} has-serif-title{{/match}}{{#match @custom.body_font "=" "Elegant serif"}} has-serif-body{{/match}}">


### PR DESCRIPTION
**Motivation**
new deriv tech blog is now in deriv.com/derivtech. we need to update our current deriv blog in ghost canonical header to the new website

**changes**
- add logic to render custom canonical tags with the new canonical tags